### PR TITLE
fix: AppLovinModule.LoadAdUnit() is called before MaxSdk is initialized

### DIFF
--- a/Assets/HuynnSDK/AdBridge.cs
+++ b/Assets/HuynnSDK/AdBridge.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GameDevToi.ThirdLib.Core;
 using GameDevToi.ThirdLib.AdModule;
 
@@ -52,7 +53,9 @@ namespace GameDevToi.ThirdLib
             }
         }
 
-        private void Awake()
+        #region MonoBehaviour Callbacks
+
+        private async void Awake()
         {
             if (instance != null && instance != this)
             {
@@ -63,7 +66,7 @@ namespace GameDevToi.ThirdLib
             instance = this;
             DontDestroyOnLoad(gameObject);
 
-            Initialize();
+            await InitializeAsync();
         }
 
         private void OnApplicationQuit()
@@ -71,10 +74,12 @@ namespace GameDevToi.ThirdLib
             isQuitting = true;
         }
 
+        #endregion
+
         /// <summary>
         /// Khởi tạo AdBridge và các module
         /// </summary>
-        private void Initialize()
+        private async Task InitializeAsync()
         {
             if (isInitialized)
             {
@@ -99,7 +104,7 @@ namespace GameDevToi.ThirdLib
             RegisterBuiltInModules();
 
             // Phân tích ad units và init các module cần thiết
-            InitializeRequiredModules();
+            await InitializeRequiredModulesAsync();
 
             isInitialized = true;
             Debug.Log("[AdBridge] Initialization completed");
@@ -172,7 +177,7 @@ namespace GameDevToi.ThirdLib
         /// <summary>
         /// Phân tích ad units và khởi tạo các module cần thiết
         /// </summary>
-        private void InitializeRequiredModules()
+        private async Task InitializeRequiredModulesAsync()
         {
             if (config.adUnits == null || config.adUnits.Count == 0)
             {
@@ -192,21 +197,28 @@ namespace GameDevToi.ThirdLib
             // Khởi tạo từng module
             foreach (var networkId in usedNetworks)
             {
-                if (adModules.ContainsKey(networkId))
+                if (!adModules.ContainsKey(networkId))
                 {
-                    var networkDef = AdRegistry.GetNetwork(networkId);
-                    string displayName = networkDef?.displayName ?? networkId;
-                    Debug.Log($"[AdBridge] Initializing {displayName} module...");
+                    Debug.LogWarning($"[AdBridge] Module for '{networkId}' not registered");
+                    continue;
+                }
+                
+                var module = adModules[networkId];
+                var networkDef = AdRegistry.GetNetwork(networkId);
+                string displayName = networkDef?.displayName ?? networkId;
+                Debug.Log($"[AdBridge] Initializing {displayName} module...");
 
-                    adModules[networkId].Initialize(config);
-
-                    // Load các ad units của network này
-                    LoadAdUnitsForNetwork(networkId);
+                if (module is BaseAdNetworkModule baseModule)
+                {
+                    await baseModule.InitializeAsync(config);
                 }
                 else
                 {
-                    Debug.LogWarning($"[AdBridge] Module for '{networkId}' not registered");
+                    module.Initialize(config);
                 }
+
+                // Load các ad units của network này
+                LoadAdUnitsForNetwork(networkId);
             }
         }
 
@@ -327,7 +339,7 @@ namespace GameDevToi.ThirdLib
 
             Debug.Log("[AdBridge] Reloading ad units...");
             config = ThirdLibConfig.Instance;
-            InitializeRequiredModules();
+            InitializeRequiredModulesAsync();
         }
 
         /// <summary>

--- a/Assets/HuynnSDK/AdModule/AdModuleConst.cs
+++ b/Assets/HuynnSDK/AdModule/AdModuleConst.cs
@@ -1,0 +1,10 @@
+namespace GameDevToi.ThirdLib.AdModule
+{
+    public static partial class AdModuleConst
+    {
+        public const string APPLOVIN_BANNER_FORMAT_ID = "banner";
+        public const string APPLOVIN_INTERSTITIAL_FORMAT_ID = "interstitial";
+        public const string APPLOVIN_REWARDED_FORMAT_ID = "rewarded";
+        public const string APPLOVIN_APP_OPEN_FORMAT_ID = "appopen";
+    }
+}

--- a/Assets/HuynnSDK/AdModule/AdModuleConst.cs.meta
+++ b/Assets/HuynnSDK/AdModule/AdModuleConst.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c92c5abdb4226724985ad1691820362c

--- a/Assets/HuynnSDK/AdModule/AppLovinModule.cs
+++ b/Assets/HuynnSDK/AdModule/AppLovinModule.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 using GameDevToi.ThirdLib.Core;
 
@@ -15,34 +16,81 @@ namespace GameDevToi.ThirdLib.AdModule
         // Dictionary to store ad unit IDs by format
         private Dictionary<string, string> adUnitIds = new Dictionary<string, string>();
         private HashSet<string> loadedAds = new HashSet<string>();
+        private TaskCompletionSource<bool> initTcs;
+
+        #region Initialization
 
         public override void Initialize(ThirdLibConfig config)
         {
             base.Initialize(config);
 
-            string sdkKey = config.appLovinSdkKey;
+            if (!ValidateConfig(config)) return;
+            LogInfo($"AppLovin initializing with SDK Key: {config.appLovinSdkKey}");
 
-            if (string.IsNullOrEmpty(sdkKey))
-            {
-                LogWarning("AppLovin SDK Key not configured");
-                return;
-            }
-
-            LogInfo($"AppLovin initializing with SDK Key: {sdkKey}");
-
-            // SDK Key should be set in AppLovin Integration Manager
             MaxSdk.InitializeSdk();
-
-            // Setup callbacks
             MaxSdkCallbacks.OnSdkInitializedEvent += (MaxSdkBase.SdkConfiguration sdkConfiguration) =>
             {
                 isInitialized = true;
                 LogInfo("AppLovin MAX initialized successfully");
             };
-
-            // Attach ad callbacks
+            
             AttachAdCallbacks();
         }
+        
+        public override async Task InitializeAsync(ThirdLibConfig config)
+        {
+            // Early return if already initialized
+            if (isInitialized && initTcs == null)
+                return;
+
+            // Await existing initialization
+            if (initTcs != null && !initTcs.Task.IsCompleted)
+            {
+                await initTcs.Task;
+                return;
+            }
+
+            await base.InitializeAsync(config);
+            
+            if (!ValidateConfig(config)) return;
+            
+            LogInfo($"AppLovin initializing with SDK Key: {config.appLovinSdkKey}");
+
+            initTcs = new TaskCompletionSource<bool>();
+
+            MaxSdkCallbacks.OnSdkInitializedEvent -= OnSdkInitialized; // safety
+            // subscribe before init to avoid missing the callback
+            MaxSdkCallbacks.OnSdkInitializedEvent += OnSdkInitialized;
+
+            MaxSdk.InitializeSdk();
+            AttachAdCallbacks();
+
+            // wait until callback fires
+            await initTcs.Task;
+        }
+        
+        private void OnSdkInitialized(MaxSdkBase.SdkConfiguration sdkConfiguration)
+        {
+            MaxSdkCallbacks.OnSdkInitializedEvent -= OnSdkInitialized;
+
+            isInitialized = true;
+            LogInfo("AppLovin MAX initialized successfully");
+
+            initTcs?.TrySetResult(true);
+            initTcs = null;
+        }
+        
+        private bool ValidateConfig(ThirdLibConfig config)
+        {
+            if (string.IsNullOrEmpty(config.appLovinSdkKey))
+            {
+                LogWarning("AppLovin SDK Key not configured");
+                return false;
+            }
+            return true;
+        }
+
+        #endregion
 
         private void AttachAdCallbacks()
         {
@@ -85,7 +133,7 @@ namespace GameDevToi.ThirdLib.AdModule
             string adUnitId = adUnit.GetAdUnitId();
             var formatDef = adUnit.GetFormat();
             string formatName = formatDef?.displayName ?? adUnit.formatId;
-            LogInfo($"Loading {formatName} ad with ID: {adUnitId}");
+            LogInfo($"Loading {formatName} ad with ID: {adUnitId}, format: {formatDef}");
 
             // Store ad unit ID
             adUnitIds[adUnit.formatId] = adUnitId;

--- a/Assets/HuynnSDK/AdModule/BaseAdNetworkModule.cs
+++ b/Assets/HuynnSDK/AdModule/BaseAdNetworkModule.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using UnityEngine;
 using GameDevToi.ThirdLib.Core;
 
@@ -22,6 +23,17 @@ namespace GameDevToi.ThirdLib.AdModule
             var networkDef = AdRegistry.GetNetwork(NetworkId);
             string displayName = networkDef?.displayName ?? NetworkId;
             Debug.Log($"[{displayName}] Initializing...");
+            
+            // _ = InitializeAsync(config);
+        }
+        
+        public virtual async Task InitializeAsync(ThirdLibConfig config)
+        {
+            this.config = config;
+            var networkDef = AdRegistry.GetNetwork(NetworkId);
+            string displayName = networkDef?.displayName ?? NetworkId;
+            Debug.Log($"[{displayName}] Initializing...");
+            await Task.CompletedTask;
         }
 
         public abstract void LoadAdUnit(AdUnit adUnit);
@@ -47,6 +59,8 @@ namespace GameDevToi.ThirdLib.AdModule
             LogWarning("ShowBanner not implemented for this network");
         }
 
+        #region Log Helpers
+        
         protected void LogInfo(string message)
         {
             var networkDef = AdRegistry.GetNetwork(NetworkId);
@@ -67,5 +81,7 @@ namespace GameDevToi.ThirdLib.AdModule
             string displayName = networkDef?.displayName ?? NetworkId;
             Debug.LogError($"[{displayName}] {message}");
         }
+        
+        #endregion
     }
 }

--- a/Assets/HuynnSDK/AdModule/IAdNetworkModule.cs
+++ b/Assets/HuynnSDK/AdModule/IAdNetworkModule.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using GameDevToi.ThirdLib.Core;
 
 namespace GameDevToi.ThirdLib.AdModule


### PR DESCRIPTION
# Modified
- Use async/await for the initialize state of ApplovinModule

# Added
- AdModuleConst.cs: contains string for ad-formatIds to prevent magic values in code
- InitializeAsync mechanic for the BaseAdNetworkModule.cs